### PR TITLE
feat: use shadcn Button for sign in and sign up buttons

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -8,6 +8,7 @@ import {
   UserButton,
 } from "@clerk/nextjs";
 import { Geist, Geist_Mono } from "next/font/google";
+import { Button } from "@/components/ui/button";
 import "./globals.css";
 
 const geistSans = Geist({
@@ -41,8 +42,12 @@ export default function RootLayout({
             <span className="text-lg font-bold">Lifting Diary</span>
             <div className="flex items-center gap-4">
               <SignedOut>
-                <SignInButton mode="modal" />
-                <SignUpButton mode="modal" />
+                <SignInButton mode="modal">
+                  <Button variant="outline">Sign In</Button>
+                </SignInButton>
+                <SignUpButton mode="modal">
+                  <Button>Sign Up</Button>
+                </SignUpButton>
               </SignedOut>
               <SignedIn>
                 <UserButton />


### PR DESCRIPTION
Closes #3

Replace plain Clerk-rendered button tags with shadcn UI Button components. SignInButton uses `variant="outline"` and SignUpButton uses the default variant.

Generated with [Claude Code](https://claude.ai/code)