### PR TITLE
feat: enable dark mode across the entire site

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -32,7 +32,7 @@ export default function RootLayout({
 }>) {
   return (
     <ClerkProvider>
-      <html lang="en">
+      <html lang="en" className="dark">
         <body
           className={`${geistSans.variable} ${geistMono.variable} antialiased`}
           suppressHydrationWarning


### PR DESCRIPTION
Add 'dark' class to the <html> element to activate dark mode globally site-wide.

Fixes #4

Generated with [Claude Code](https://claude.ai/code)